### PR TITLE
Extending HealthService to probe pods

### DIFF
--- a/src/app/AlwaysOn.HealthService/AlwaysOnHealthCheck.cs
+++ b/src/app/AlwaysOn.HealthService/AlwaysOnHealthCheck.cs
@@ -116,9 +116,9 @@ namespace AlwaysOn.HealthService
         private async Task<bool> GetLivenessEndpoint1Status(CancellationToken cancellationToken = default (CancellationToken))
         {
             var result = true;
-
+            _log.LogInformation("Initiated liveness endpoint 1 {livenessEndpoint1} probe check", _sysConfig.LivenessEndpoint1);
             try {
-                _log.LogInformation("Initiated liveness endpoint 1 {livenessEndpoint1} probe check", _sysConfig.LivenessEndpoint1);
+                
                 var status = await GetStatusCodes(_sysConfig.LivenessEndpoint1);
 
                 if (status==HttpStatusCode.OK) {
@@ -127,12 +127,15 @@ namespace AlwaysOn.HealthService
                     _log.LogInformation("Liveness probe for {livenessEndpoint1} responded with HTTP != 200", _sysConfig.LivenessEndpoint1);
                     result=false;
                 }
+
+                return result;
+
             } catch (Exception e) {
-                result=false;
                 _log.LogError(e, "Could not check liveness endpoint 1 probe. Responding with UNHEALTHY state");
+                return false;
             }
 
-            return result;
+
 
         }
 

--- a/src/app/AlwaysOn.HealthService/AlwaysOnHealthCheck.cs
+++ b/src/app/AlwaysOn.HealthService/AlwaysOnHealthCheck.cs
@@ -118,13 +118,13 @@ namespace AlwaysOn.HealthService
             var result = true;
 
             try {
-                _log.LogInformation("Initiated liveness endpoint 1 probe check");
+                _log.LogInformation("Initiated liveness endpoint 1 {livenessEndpoint1} probe check", _sysConfig.LivenessEndpoint1);
                 var status = await GetStatusCodes(_sysConfig.LivenessEndpoint1);
 
                 if (status==HttpStatusCode.OK) {
                     result=true;
                 } else {
-                    _log.LogInformation("Liveness probe responded with HTTP != 200");
+                    _log.LogInformation("Liveness probe for {livenessEndpoint1} responded with HTTP != 200", _sysConfig.LivenessEndpoint1);
                     result=false;
                 }
             } catch (Exception e) {

--- a/src/app/AlwaysOn.Shared/SysConfiguration.cs
+++ b/src/app/AlwaysOn.Shared/SysConfiguration.cs
@@ -138,6 +138,8 @@ namespace AlwaysOn.Shared
             }
         }
 
+        public string LivenessEndpoint1 => Configuration["LIVENESS_ENDPOINT_1"];
+
         public string HealthServiceStorageConnectionString => Configuration["STORAGEACCOUNT_CONNECTIONSTRING"];
         public string HealthServiceBlobContainerName => Configuration["STORAGEACCOUNT_HEALTHSERVICE_CONTAINERNAME"];
         public string HealthServiceBlobName => Configuration["STORAGEACCOUNT_HEALTHSERVICE_BLOBNAME"];

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: {{ .Values.azure.region }}
             - name: "ASPNETCORE_URLS" # Port used to start the ASP.NET Core application
               value: "http://+:{{ .Values.workload.port | default 8080 }}"
+            - name: "LIVENESS_ENDPOINT_1" # Liveness Endpoint 1
+              value: "{{ .Values.probes.catalogservice }}"              
         volumeMounts:
           - name: secrets-store-inline
             mountPath: "/mnt/secrets-store"

--- a/src/app/charts/healthservice/values.yaml
+++ b/src/app/charts/healthservice/values.yaml
@@ -14,4 +14,4 @@ azure:
   region: "East US 2"
 
 probes:
-  catalogservice: "http://catalogservice:8080/health/liveness"
+  catalogservice: "http://catalogservice-service:8080/health/liveness"

--- a/src/app/charts/healthservice/values.yaml
+++ b/src/app/charts/healthservice/values.yaml
@@ -12,3 +12,6 @@ replicas: 3
 
 azure:
   region: "East US 2"
+
+probes:
+  catalogservice: "http://catalogservice:8080/health/liveness"


### PR DESCRIPTION
@msimecek / @sebader following up on the conversation we had in #98 what do you guys think about adding 1, 2 or more additional `LIVENESS_ENDPOINT_x` (name is tdb) the healthservice can probe additionally to what it does today. 

This will of course not probe each individual pod - it will use the ClusterIP service instead.

```mermaid
stateDiagram
    direction LR
    [*] --> StampHealthCheck
    state FrontDoor {
    StampHealthCheck --> HealthService
    }
    state AKS {
        direction RL
        HealthService
        HealthService --> Application: Alive?
        HealthService --> BackendProcess: Alive?
    }
    HealthService --> CosmosDB: Able to query?
    HealthService --> Storage: File exists?
    HealthService --> EventHubs: Able to sent message?
```

Treat my implementation just a sample I've used to test that - you can probably implement it better.