### PR TITLE
Skip Component Governance Detection

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -47,3 +47,5 @@ variables:
   value: '20'
 - name: 'smokeTestRetryWaitSeconds' # How long to wait between each retry of the smoke tests
   value: '60'
+- name: 'skipComponentGovernanceDetection' # This is a Microsoft-specific setting. Having this in place ensures we don't create work items with CELA every time we use an open-source component
+  value: 'true'


### PR DESCRIPTION
Adding this variable opts out of the Microsoft component governance detection, the step will not be auto-inserted into the pipelines