### PR TITLE
Drop AKS `addon_profile` 

### DIFF
--- a/src/infra/workload/releaseunit/main.tf
+++ b/src/infra/workload/releaseunit/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.96.0"
+      version = "2.97.0"
     }
   }
 

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -63,6 +63,7 @@ resource "azurerm_kubernetes_cluster" "stamp" {
     log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
   }
 
+  # Enable and configure the Azure KeyVault Secrets Provider addon for AKS
   azure_keyvault_secrets_provider {
     enabled                  = true
     secret_rotation_enabled  = true

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -59,12 +59,11 @@ resource "azurerm_kubernetes_cluster" "stamp" {
 
   # Enable and configure the Azure Monitor (container insights) addon for AKS
   oms_agent {
-    enabled                    = true
     log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
   }
 
   # Enable and configure the Azure KeyVault Secrets Provider addon for AKS
-  azure_keyvault_secrets_provider {
+  key_vault_secrets_provider {
     enabled                  = true
     secret_rotation_enabled  = true
     secret_rotation_interval = "5m"

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -6,7 +6,7 @@ resource "azurerm_kubernetes_cluster" "stamp" {
   dns_prefix          = "${local.prefix}${var.location}aks"
   kubernetes_version  = var.kubernetes_version
   node_resource_group = "MC_${local.prefix}-stamp-${var.location}-aks-rg" # we manually specify the naming of the managed resource group to have it controlled and consistent
-  sku_tier            = "Paid"                                          # Opt-in for AKS Uptime SLA
+  sku_tier            = "Paid"                                            # Opt-in for AKS Uptime SLA
 
   automatic_channel_upgrade = "node-image"
 

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -64,7 +64,6 @@ resource "azurerm_kubernetes_cluster" "stamp" {
 
   # Enable and configure the Azure KeyVault Secrets Provider addon for AKS
   key_vault_secrets_provider {
-    enabled                  = true
     secret_rotation_enabled  = true
     secret_rotation_interval = "5m"
   }

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -52,11 +52,6 @@ resource "azurerm_kubernetes_cluster" "stamp" {
   # Enable the Azure Policy Addon for AKS
   azure_policy_enabled = true
 
-  # Disable the builtin Kubernetes dashboard
-  kube_dashboard {
-    enabled = false
-  }
-
   # Enable and configure the Azure Monitor (container insights) addon for AKS
   oms_agent {
     log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -49,25 +49,24 @@ resource "azurerm_kubernetes_cluster" "stamp" {
     type = "SystemAssigned"
   }
 
-  addon_profile {
-    oms_agent {
-      enabled                    = true
-      log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
-    }
+  # Enable the Azure Policy Addon for AKS
+  azure_policy_enabled = true
 
-    azure_policy {
-      enabled = true
-    }
+  # Disable the builtin Kubernetes dashboard
+  kube_dashboard {
+    enabled = false
+  }
 
-    kube_dashboard {
-      enabled = false
-    }
+  # Enable and configure the Azure Monitor (container insights) addon for AKS
+  oms_agent {
+    enabled                    = true
+    log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
+  }
 
-    azure_keyvault_secrets_provider {
-      enabled                  = true
-      secret_rotation_enabled  = true
-      secret_rotation_interval = "5m"
-    }
+  azure_keyvault_secrets_provider {
+    enabled                  = true
+    secret_rotation_enabled  = true
+    secret_rotation_interval = "5m"
   }
 
   depends_on = [


### PR DESCRIPTION
This PR drops the use of the deprecated `addon_profile` in AKS. 