### PR TITLE
Move locust config to central config file

### DIFF
--- a/.ado/pipelines/azure-deploy-locust.yaml
+++ b/.ado/pipelines/azure-deploy-locust.yaml
@@ -21,7 +21,7 @@ parameters:
   type: number
   default: 0
 
-- name: locustTargetUrl
+- name: loadTestTargetUrl
   displayName: 'Loadtest Target URL (can be overriden later)'
   type: string
   default: "https://www.int.shop.always-on.app"
@@ -43,6 +43,6 @@ stages:
   parameters:
     terraformWorkingDirectory: '$(workingDirectory)'
     customPrefix: '$(prefix)'
-    locustTargetUrl: ${{ parameters.locustTargetUrl }}
+    loadTestTargetUrl: ${{ parameters.loadTestTargetUrl }}
     loadTestNumberOfWorkerNodes: ${{ parameters.loadTestNumberOfWorkerNodes }}
     locustHeadless: false # set to false to run in webui mode

--- a/.ado/pipelines/azure-deploy-locust.yaml
+++ b/.ado/pipelines/azure-deploy-locust.yaml
@@ -16,7 +16,7 @@ parameters:
   - int
   - prod
 
-- name: numberOfWorkerNodes
+- name: loadTestNumberOfWorkerNodes
   displayName: 'Number of Worker Nodes. Set to 0 to also destroy the master node.'
   type: number
   default: 0
@@ -44,5 +44,5 @@ stages:
     terraformWorkingDirectory: '$(workingDirectory)'
     customPrefix: '$(prefix)'
     locustTargetUrl: ${{ parameters.locustTargetUrl }}
-    numberOfWorkerNodes: ${{ parameters.numberOfWorkerNodes }}
+    loadTestNumberOfWorkerNodes: ${{ parameters.loadTestNumberOfWorkerNodes }}
     locustHeadless: false # set to false to run in webui mode

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -50,7 +50,7 @@ variables:
   value: 300
 - name: 'loadTestNumberOfUsers' # number of simulated users in the load test
   value: 500
-- name: 'loadTestUserSpawnRate' # locust spawn rate users / per second
+- name: 'loadTestUserSpawnRate' # load test spawn rate users / per second
   value: 10
 
 # Others

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -42,7 +42,7 @@ variables:
 - name: 'healthserviceImageName'
   value: 'alwayson/healthservice'
 
-# Embedded load testing (locust) configuration
+# Embedded load testing configuration
 # Make sure that these parameters are aligned with the loadtest-baseline.yaml
 - name: 'loadTestNumberOfWorkerNodes' # number of worker nodes
   value: 10

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -45,13 +45,13 @@ variables:
 # Embedded load testing (locust) configuration
 # Make sure that these parameters are aligned with the loadtest-baseline.yaml
 - name: 'loadTestNumberOfWorkerNodes' # number of locust worker nodes
-  value: '10'
+  value: 10
 - name: 'loadTestDurationInSeconds' # locust test duration
-  value: '300'
+  value: 300
 - name: 'loadTestNumberOfUsers' # locust number of simulated users
-  value: '500'
+  value: 500
 - name: 'loadTestUserSpawnRate' # locust spawn rate users / per second
-  value: '10'
+  value: 10
 
 # Others
 - name: 'smokeTestRetryCount' # How many times a request in the smoke tests is retried before declared as failed (retries HTTP response codes from 400-599 as well as issues like certificate errors)

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -42,6 +42,17 @@ variables:
 - name: 'healthserviceImageName'
   value: 'alwayson/healthservice'
 
+# Embedded load testing (locust) configuration
+# Make sure that these parameters are aligned with the loadtest-baseline.yaml
+- name: 'loadTestNumberOfWorkerNodes' # number of locust worker nodes
+  value: '10'
+- name: 'loadTestDurationInSeconds' # locust test duration
+  value: '300'
+- name: 'loadTestNumberOfUsers' # locust number of simulated users
+  value: '500'
+- name: 'loadTestUserSpawnRate' # locust spawn rate users / per second
+  value: '10'
+
 # Others
 - name: 'smokeTestRetryCount' # How many times a request in the smoke tests is retried before declared as failed (retries HTTP response codes from 400-599 as well as issues like certificate errors)
   value: '20'

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -46,7 +46,7 @@ variables:
 # Make sure that these parameters are aligned with the loadtest-baseline.yaml
 - name: 'loadTestNumberOfWorkerNodes' # number of worker nodes
   value: 10
-- name: 'loadTestDurationInSeconds' # locust test duration
+- name: 'loadTestDurationInSeconds' # load test duration
   value: 300
 - name: 'loadTestNumberOfUsers' # number of simulated users in the load test
   value: 500

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -48,7 +48,7 @@ variables:
   value: 10
 - name: 'loadTestDurationInSeconds' # locust test duration
   value: 300
-- name: 'loadTestNumberOfUsers' # locust number of simulated users
+- name: 'loadTestNumberOfUsers' # number of simulated users in the load test
   value: 500
 - name: 'loadTestUserSpawnRate' # locust spawn rate users / per second
   value: 10

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -44,7 +44,7 @@ variables:
 
 # Embedded load testing (locust) configuration
 # Make sure that these parameters are aligned with the loadtest-baseline.yaml
-- name: 'loadTestNumberOfWorkerNodes' # number of locust worker nodes
+- name: 'loadTestNumberOfWorkerNodes' # number of worker nodes
   value: 10
 - name: 'loadTestDurationInSeconds' # locust test duration
   value: 300

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -311,10 +311,10 @@ stages:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
       numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
-      testDurationSeconds: $(loadTestDurationInSeconds) # locust test duration
-      locustUser: $(loadTestNumberOfUsers) # locust number of simulated users
-      locustSpawnRate: $(loadTestUserSpawnRate) # locust spawn rate users / per second
-      locustHeadless: true # run locust in headless mode
+      testDurationSeconds: $(loadTestDurationInSeconds) # load test duration
+      locustUser: $(loadTestNumberOfUsers) # number of simulated users
+      locustSpawnRate: $(loadTestUserSpawnRate) # spawn rate users / per second
+      locustHeadless: true # run locust load test in headless mode
 
 # Chaos testing for e2e (optional) with Azure Chaos Studio
 - ${{ if and(eq(parameters.environment, 'e2e'), eq(parameters.runChaosTesting, 'true')) }}: # only in e2e and when runChaosTesting is true

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -19,8 +19,6 @@ parameters:
 
 stages:
 
-- template: ../config/configuration.yaml
-
 - stage: deployglobalinfrastructure
   displayName: 'Deploy Global Infrastructure' # Deploy Global Azure Infrastructure
   jobs:

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -310,8 +310,8 @@ stages:
     parameters:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
-      numberOfWorkerNodes: ${{ variables.loadTestNumberOfWorkerNodes }} # number of locust worker nodes
-      testDurationSeconds: ${{ variables.loadTestDurationInSeconds }} # locust test duration
+      numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes) # number of locust worker nodes
+      testDurationSeconds: $(loadTestDurationInSeconds) # locust test duration
       locustUser: $(loadTestNumberOfUsers) # locust number of simulated users
       locustSpawnRate: $(loadTestUserSpawnRate) # locust spawn rate users / per second
       locustHeadless: true # run locust in headless mode

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -311,7 +311,7 @@ stages:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
       numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
-      testDurationSeconds: $(loadTestDurationInSeconds) # load test duration
+      testDurationSeconds: $(loadTestDurationInSeconds)
       locustUser: $(loadTestNumberOfUsers) # number of simulated users
       locustSpawnRate: $(loadTestUserSpawnRate) # spawn rate users / per second
       locustHeadless: true # run locust load test in headless mode

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -19,6 +19,8 @@ parameters:
 
 stages:
 
+- template: ../config/configuration.yaml
+
 - stage: deployglobalinfrastructure
   displayName: 'Deploy Global Infrastructure' # Deploy Global Azure Infrastructure
   jobs:

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -312,7 +312,7 @@ stages:
       customPrefix: '$(prefix)$(customSuffix)'
       numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
       testDurationSeconds: $(loadTestDurationInSeconds)
-      locustUser: $(loadTestNumberOfUsers) # number of simulated users
+      locustUser: $(loadTestNumberOfUsers)
       locustSpawnRate: $(loadTestUserSpawnRate) # spawn rate users / per second
       locustHeadless: true # run locust load test in headless mode
 

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -310,10 +310,10 @@ stages:
     parameters:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
-      numberOfWorkerNodes: 10 # number of locust worker nodes
-      testDurationSeconds: 300 # locust test duration
-      locustUser: 500 # locust number of simulated users
-      locustSpawnRate: 10 # locust spawn rate users / per second
+      numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes) # number of locust worker nodes
+      testDurationSeconds: $(loadTestDurationInSeconds) # locust test duration
+      locustUser: $(loadTestNumberOfUsers) # locust number of simulated users
+      locustSpawnRate: $(loadTestUserSpawnRate) # locust spawn rate users / per second
       locustHeadless: true # run locust in headless mode
 
 # Chaos testing for e2e (optional) with Azure Chaos Studio

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -310,8 +310,8 @@ stages:
     parameters:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
-      numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes) # number of locust worker nodes
-      testDurationSeconds: $(loadTestDurationInSeconds) # locust test duration
+      numberOfWorkerNodes: ${{ variables.loadTestNumberOfWorkerNodes }} # number of locust worker nodes
+      testDurationSeconds: ${{ variables.loadTestDurationInSeconds }} # locust test duration
       locustUser: $(loadTestNumberOfUsers) # locust number of simulated users
       locustSpawnRate: $(loadTestUserSpawnRate) # locust spawn rate users / per second
       locustHeadless: true # run locust in headless mode

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -310,7 +310,7 @@ stages:
     parameters:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
-      numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes) # number of locust worker nodes
+      numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
       testDurationSeconds: $(loadTestDurationInSeconds) # locust test duration
       locustUser: $(loadTestNumberOfUsers) # locust number of simulated users
       locustSpawnRate: $(loadTestUserSpawnRate) # locust spawn rate users / per second

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -313,7 +313,7 @@ stages:
       numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
       testDurationSeconds: $(loadTestDurationInSeconds)
       locustUser: $(loadTestNumberOfUsers)
-      locustSpawnRate: $(loadTestUserSpawnRate) # spawn rate users / per second
+      locustSpawnRate: $(loadTestUserSpawnRate)
       locustHeadless: true # run locust load test in headless mode
 
 # Chaos testing for e2e (optional) with Azure Chaos Studio

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -310,11 +310,11 @@ stages:
     parameters:
       terraformWorkingDirectory: 'src/testing/loadtest-locust/infra'
       customPrefix: '$(prefix)$(customSuffix)'
-      numberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
-      testDurationSeconds: $(loadTestDurationInSeconds)
-      locustUser: $(loadTestNumberOfUsers)
-      locustSpawnRate: $(loadTestUserSpawnRate)
-      locustHeadless: true # run locust load test in headless mode
+      loadTestNumberOfWorkerNodes: $(loadTestNumberOfWorkerNodes)
+      loadTestDurationInSeconds: $(loadTestDurationInSeconds)
+      loadTestNumberOfUsers: $(loadTestNumberOfUsers)
+      loadTestUserSpawnRate: $(loadTestUserSpawnRate)
+      locustHeadless: true # run locust in headless mode
 
 # Chaos testing for e2e (optional) with Azure Chaos Studio
 - ${{ if and(eq(parameters.environment, 'e2e'), eq(parameters.runChaosTesting, 'true')) }}: # only in e2e and when runChaosTesting is true

--- a/.ado/pipelines/templates/stages-locust.yaml
+++ b/.ado/pipelines/templates/stages-locust.yaml
@@ -10,13 +10,10 @@ parameters:
  - name: numberOfWorkerNodes
    default: 0
  - name: testDurationSeconds
-   type: number
    default: 0
  - name: locustSpawnRate
-   type: number
    default: 0
  - name: locustUser
-   type: number
    default: 0
  - name: locustHeadless
    type: boolean

--- a/.ado/pipelines/templates/stages-locust.yaml
+++ b/.ado/pipelines/templates/stages-locust.yaml
@@ -4,7 +4,7 @@ parameters:
    default: ''
  - name: customPrefix
    type: string
- - name: locustTargetUrl
+ - name: loadTestTargetUrl
    type: string
    default: ''
  - name: loadTestNumberOfWorkerNodes
@@ -39,15 +39,15 @@ stages:
         terraformStateFilename:             'terraform-locust-${{ parameters.customPrefix }}.state'
         terraformWorkingDirectory:          '${{ parameters.terraformWorkingDirectory }}'
 
-      # If supplied as a parameter, write locustTargetUrl parameter into a pipeline variable
-    - ${{ if ne(parameters.locustTargetUrl, '') }}:
+      # If supplied as a parameter, write loadTestTargetUrl parameter into a pipeline variable
+    - ${{ if ne(parameters.loadTestTargetUrl, '') }}:
       - task: Bash@3
         name: 'bashsetTargetUrlVariable'
-        displayName: 'Set locustTargetUrl variable'
+        displayName: 'Set loadTestTargetUrl variable'
         inputs:
           targetType: 'inline'
           script: |
-            echo "##vso[task.setvariable variable=locustTargetUrl]${{ parameters.locustTargetUrl }}"
+            echo "##vso[task.setvariable variable=loadTestTargetUrl]${{ parameters.loadTestTargetUrl }}"
 
       # parse global terraform output to fetch frontdoor fqdn (used for headless-locust-only)
     - ${{ if eq(parameters.locustHeadless, 'true') }}:
@@ -55,14 +55,14 @@ stages:
         parameters:
           workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
 
-      # overwrite locustTargetUrl pipeline variable with frontdoor fqdn (used for headless-locust-only)
+      # overwrite loadTestTargetUrl pipeline variable with frontdoor fqdn (used for headless-locust-only)
       - task: Bash@3
         name: 'bashsetTargetUrlVariableHeadless'
-        displayName: 'Set locustTargetUrl variable'
+        displayName: 'Set loadTestTargetUrl variable'
         inputs:
           targetType: 'inline'
           script: |
-            echo "##vso[task.setvariable variable=locustTargetUrl]https://$(frontdoor_fqdn)"
+            echo "##vso[task.setvariable variable=loadTestTargetUrl]https://$(frontdoor_fqdn)"
 
     - task: Bash@3
       name: 'terraformtaintlocustfile'
@@ -83,7 +83,7 @@ stages:
         terraformWorkingDirectory:  '${{ parameters.terraformWorkingDirectory }}'
         customPrefix:               '${{ parameters.customPrefix }}'
         environment:                '$(environment)'
-        customAttributes:           '-var targeturl=$(locustTargetUrl)
+        customAttributes:           '-var targeturl=$(loadTestTargetUrl)
                                     -var queued_by="$(Build.QueuedBy)"
                                     -var locust_workers=${{ parameters.loadTestNumberOfWorkerNodes }}
                                     -var locust_runtime="${{ parameters.loadTestDurationInSeconds }}s"

--- a/.ado/pipelines/templates/stages-locust.yaml
+++ b/.ado/pipelines/templates/stages-locust.yaml
@@ -8,7 +8,6 @@ parameters:
    type: string
    default: ''
  - name: numberOfWorkerNodes
-   type: number
    default: 0
  - name: testDurationSeconds
    type: number

--- a/.ado/pipelines/templates/stages-locust.yaml
+++ b/.ado/pipelines/templates/stages-locust.yaml
@@ -7,13 +7,13 @@ parameters:
  - name: locustTargetUrl
    type: string
    default: ''
- - name: numberOfWorkerNodes
+ - name: loadTestNumberOfWorkerNodes
    default: 0
- - name: testDurationSeconds
+ - name: loadTestDurationInSeconds
    default: 0
- - name: locustSpawnRate
+ - name: loadTestUserSpawnRate
    default: 0
- - name: locustUser
+ - name: loadTestNumberOfUsers
    default: 0
  - name: locustHeadless
    type: boolean
@@ -85,22 +85,22 @@ stages:
         environment:                '$(environment)'
         customAttributes:           '-var targeturl=$(locustTargetUrl)
                                     -var queued_by="$(Build.QueuedBy)"
-                                    -var locust_workers=${{ parameters.numberOfWorkerNodes }}
-                                    -var locust_runtime="${{ parameters.testDurationSeconds }}s"
-                                    -var locust_spawn_rate=${{ parameters.locustSpawnRate }}
+                                    -var locust_workers=${{ parameters.loadTestNumberOfWorkerNodes }}
+                                    -var locust_runtime="${{ parameters.loadTestDurationInSeconds }}s"
+                                    -var locust_spawn_rate=${{ parameters.loadTestUserSpawnRate }}
                                     -var locust_headless="${{ lower(parameters.locustHeadless) }}"
-                                    -var locust_number_of_users=${{ parameters.locustUser }}'
+                                    -var locust_number_of_users=${{ parameters.loadTestNumberOfUsers }}'
 
     # All of the next tasks are only applicable in headless mode
     - ${{ if eq(parameters.locustHeadless, 'true') }}:
       # Sleep for the duration of the load test
       - task: Bash@3
-        displayName: 'Sleep for ${{ parameters.testDurationSeconds }} seconds'
+        displayName: 'Sleep for ${{ parameters.loadTestDurationInSeconds }} seconds'
         inputs:
           targetType: 'inline'
           script: |
-            echo "Sleeping for ${{ parameters.testDurationSeconds }} seconds while the test is running..."
-            sleep ${{ parameters.testDurationSeconds }}
+            echo "Sleeping for ${{ parameters.loadTestDurationInSeconds }} seconds while the test is running..."
+            sleep ${{ parameters.loadTestDurationInSeconds }}
 
     # Download locust stats and logs from storage account to build agent so we can then store it as a pipeline artifact
       - task: Bash@3


### PR DESCRIPTION
This was brought up in yesterday's LevelUp session - the embedded locust config is currently burried in our pipeline code. This PR will change that and move the embedded locust config over to our central config file in `.ado/pipelines/config`.

This will close issue #151 